### PR TITLE
Merged multigrid functionality into PoissonSinx example

### DIFF
--- a/LinearAlgebra/d4est_linalg.c
+++ b/LinearAlgebra/d4est_linalg.c
@@ -52,9 +52,9 @@ d4est_linalg_leftinverse(double *A, double* inv_A, int A_rows, int A_cols)
 }
 
 
-/** 
+/**
  C = A*B
- * 
+ *
  * @param A matrix of dimension m by l
  * @param B matrix of dimension l by n
  * @param C matrix of dimension m by n
@@ -121,13 +121,13 @@ d4est_linalg_mat_transpose (double *A, double *Atrans, int N)
       Atrans[i * N + j] = A[j * N + i];
 }
 
-/** 
- * 
- * 
- * @param A 
- * @param A_transpose 
- * @param A_rows 
- * @param A_cols 
+/**
+ *
+ *
+ * @param A
+ * @param A_transpose
+ * @param A_rows
+ * @param A_cols
  */
 void
 d4est_linalg_mat_transpose_nonsqr (double *A, double *A_transpose, int A_rows,
@@ -139,12 +139,12 @@ d4est_linalg_mat_transpose_nonsqr (double *A, double *A_transpose, int A_rows,
       A_transpose[j * A_rows + i] = A[i * A_cols + j];
 }
 
-/** 
+/**
  * Only for debugging purposes, or small matrices.
  * This should not be called many times.
- * 
- * @param A 
- * @param column 
+ *
+ * @param A
+ * @param column
  * @param N rows
  * @param M columns
  */
@@ -187,7 +187,7 @@ d4est_linalg_vec_normalize(double*x, int N)
 {
   double xdotx = d4est_linalg_vec_dot(x,x,N);
   double norm = sqrt(xdotx);
-  d4est_linalg_vec_scale(norm, x, N); 
+  d4est_linalg_vec_scale(norm, x, N);
 }
 
 void d4est_linalg_vec_gen_random(double* vec, int N, long int seed, double a, double b){
@@ -242,14 +242,14 @@ d4est_linalg_fill_vec (double *v, double val, int N)
     v[i] = val;
 }
 
-/** 
- * This routine will work irrespective of the 
+/**
+ * This routine will work irrespective of the
  * data order (COL or ROW major) b.c the matrix is
  * symmetric
- * 
+ *
  * @param A an NxN matrix
- * @param eig_vals vector of eigen values 
- * @param N 
+ * @param eig_vals vector of eigen values
+ * @param N
  */
 void
 d4est_linalg_sym_eigvals (double *A, double *eig_vals, int N)
@@ -287,6 +287,13 @@ d4est_linalg_vec_fabs(double* x, int N)
 }
 
 void
+d4est_linalg_vec_fabsdiff(double* x, double* y, double* result, int N)
+{
+  d4est_linalg_vec_axpyeqz(-1., x, y, result, N);
+  d4est_linalg_vec_fabs(result, N);
+}
+
+void
 d4est_linalg_component_mult
 (
  double* x,
@@ -320,11 +327,11 @@ d4est_linalg_component_div
 }
 
 
-/** 
+/**
  * return v1 \cross v2
- * 
+ *
  * @param v1
- * @param v2 
+ * @param v2
  */
 void
 d4est_linalg_cross_prod
@@ -372,7 +379,7 @@ d4est_linalg_vec1_trans_mat_vec2
 {
 
   double *mat_vec2 = (double *) malloc (sizeof (double) * N);
-  d4est_linalg_matvec_plus_vec(1., mat, vec2, 0., mat_vec2, N, N);                      
+  d4est_linalg_matvec_plus_vec(1., mat, vec2, 0., mat_vec2, N, N);
   double dot = d4est_linalg_vec_dot(vec1, mat_vec2, N);
   free(mat_vec2);
   return dot;

--- a/LinearAlgebra/d4est_linalg.h
+++ b/LinearAlgebra/d4est_linalg.h
@@ -9,6 +9,7 @@ void d4est_linalg_cross_prod(double ax,double ay,double az,double bx,double by,d
 void d4est_linalg_component_div(double *x,double *y,double *xdivy,int N);
 void d4est_linalg_component_mult(double *x,double *y,double *xy,int N);
 void d4est_linalg_vec_fabs(double *x,int N);
+void d4est_linalg_vec_fabsdiff(double* x, double* y, double* result, int N);
 void d4est_linalg_sym_eigvecs(double *A,double *eig_vals,int N);
 void d4est_linalg_sym_eigvals(double *A,double *eig_vals,int N);
 void d4est_linalg_fill_vec(double *v,double val,int N);

--- a/Problems/ConstantDensityStar/constant_density_star_mgpc_newton_petsc.c
+++ b/Problems/ConstantDensityStar/constant_density_star_mgpc_newton_petsc.c
@@ -494,7 +494,7 @@ problem_init
       newton_petsc_input(p4est, input_file, "[NEWTON_PETSC]", &newton_params);
 
       krylov_petsc_params_t krylov_params;
-      krylov_petsc_input(p4est, input_file, "krylov_petsc", "[KRYLOV_PETSC]", &krylov_params);
+      krylov_petsc_input(p4est, input_file, "krylov_petsc", &krylov_params);
       
       if (p4est->mpirank == 0)
         zlog_info(c_default, "Performing Newton PETSc solve...");

--- a/Problems/PoissonSinx/options.input
+++ b/Problems/PoissonSinx/options.input
@@ -7,6 +7,7 @@ region0_deg_quad_inc = 0
 
 [problem]
 eval_method = EVAL_BNDRY_FCN_ON_LOBATTO
+deg_vol_quad_inc = 0
 
 [flux]
 name = sipg
@@ -72,12 +73,38 @@ ksp_converged_reason = 1
 ksp_initial_guess_nonzero = 0
 ksp_monitor_singular_value = 0
 
-[multigrid]
-vcycle_imax = 1;
-vcycle_rtol = 1e-9;
-vcycle_atol = 0.;
-smoother_name = mg_smoother_cheby
-bottom_solver_name = mg_bottom_solver_cg_d4est
+; [multigrid]
+; vcycle_imax = 1;
+; vcycle_rtol = 1e-9;
+; vcycle_atol = 0.;
+; smoother_name = mg_smoother_cheby
+; bottom_solver_name = mg_bottom_solver_cg_d4est
+
+[mg_bottom_solver_cg_d4est]
+bottom_iter = 100;
+bottom_rtol = 1e-10;
+bottom_atol = 0.;
+bottom_print_residual_norm = 0;
+
+[mg_smoother_cheby]
+cheby_imax = 8;
+cheby_eigs_cg_imax = 10;
+cheby_eigs_lmax_lmin_ratio = 30.;
+cheby_eigs_max_multiplier = 1.;
+cheby_eigs_reuse_fromdownvcycle = 0;
+cheby_eigs_reuse_fromlastvcycle = 0;
+cheby_print_residual_norm = 0;
+cheby_print_eigs = 0;
+
+[mg_bottom_solver_cheby]
+cheby_imax = 15;
+cheby_eigs_cg_imax = 30;
+cheby_eigs_lmax_lmin_ratio = 30.;
+cheby_eigs_max_multiplier = 1.;
+cheby_eigs_reuse_fromdownvcycle = 0;
+cheby_eigs_reuse_fromlastvcycle = 0;
+cheby_print_residual_norm = 0;
+cheby_print_eig = 0;
 
 [quadrature]
 name = legendre

--- a/Problems/PoissonSinx/poisson_sinx_uniform.c
+++ b/Problems/PoissonSinx/poisson_sinx_uniform.c
@@ -20,6 +20,10 @@
 #include <d4est_poisson_flux_sipg.h>
 #include <newton_petsc.h>
 #include <krylov_petsc.h>
+#include <krylov_pc_multigrid.h>
+#include <multigrid_logger_residual.h>
+#include <multigrid_element_data_updater.h>
+#include <multigrid.h>
 #include <d4est_util.h>
 #include <time.h>
 #include <zlog.h>
@@ -28,20 +32,12 @@
 typedef struct {
   
   dirichlet_bndry_eval_method_t eval_method;
+
+  int use_multigrid;
+  int deg_vol_quad_inc;
   
 } poisson_sinx_init_params_t;
 
-static
-int skip_element_fcn
-(
- d4est_element_data_t* ed
-)
-{
-  if(ed->tree != 12)
-    return 1;
-  else
-    return 0;
-}
 
 static
 int poisson_sinx_init_params_handler
@@ -63,8 +59,12 @@ int poisson_sinx_init_params_handler
     else {
       D4EST_ABORT("Not a supported eval method");
     }
-  }
-  else {
+  } else if (d4est_util_match_couple(section,"problem",name,"deg_vol_quad_inc")) {
+    D4EST_ASSERT(pconfig->deg_vol_quad_inc == -1);
+    pconfig->deg_vol_quad_inc = atoi(value);
+  } else if (d4est_util_match(section,"multigrid")) {
+    pconfig->use_multigrid = 1;
+  } else {
     return 0;  /* unknown section/name, error */
   }
   return 1;
@@ -80,15 +80,19 @@ poisson_sinx_init_params_input
 {
   poisson_sinx_init_params_t input;
   input.eval_method = EVAL_BNDRY_FCN_NOT_SET;
+  input.deg_vol_quad_inc = -1;
+  input.use_multigrid = 0;
 
   if (ini_parse(input_file, poisson_sinx_init_params_handler, &input) < 0) {
     D4EST_ABORT("Can't load input file");
   }
 
+  D4EST_CHECK_INPUT("problem", input.deg_vol_quad_inc, -1);
   D4EST_CHECK_INPUT("problem", input.eval_method, EVAL_BNDRY_FCN_NOT_SET);
   
   return input;
 }
+
 
 int
 problem_set_mortar_degree
@@ -98,6 +102,18 @@ problem_set_mortar_degree
 )
 {
   return elem_data->deg_vol_quad;
+}
+
+
+void
+problem_set_degrees_after_amr
+(
+ d4est_element_data_t* elem_data,
+ void* user_ctx
+)
+{
+  poisson_sinx_init_params_t* params = user_ctx;
+  elem_data->deg_vol_quad = elem_data->deg + params->deg_vol_quad_inc;
 }
 
 
@@ -120,10 +136,14 @@ problem_init
 
   int initial_nodes = initial_extents->initial_nodes;
   
-  poisson_sinx_init_params_t init_params = poisson_sinx_init_params_input(input_file
-                                                                           );
+  // Parse problem parameters
+  poisson_sinx_init_params_t init_params = poisson_sinx_init_params_input(input_file);
   dirichlet_bndry_eval_method_t eval_method = init_params.eval_method;
+  if (init_params.use_multigrid == 0 && p4est->mpirank == 0)
+    zlog_info(c_default, "Multigrid is disabled. Add a `[multigrid]` section to the input file to enable.");
+
   
+  // Setup boundary conditions
   d4est_poisson_dirichlet_bc_t bc_data_for_lhs;
   bc_data_for_lhs.dirichlet_fcn = zero_fcn;
   bc_data_for_lhs.eval_method = eval_method;
@@ -134,20 +154,19 @@ problem_init
   
   d4est_poisson_flux_data_t* flux_data_for_apply_lhs = d4est_poisson_flux_new(p4est, input_file, BC_DIRICHLET, &bc_data_for_lhs, problem_set_mortar_degree, NULL);
   
-  d4est_poisson_flux_data_t* flux_data_for_build_rhs = d4est_poisson_flux_new(p4est, input_file,  BC_DIRICHLET, &bc_data_for_rhs, problem_set_mortar_degree, NULL);
+  d4est_poisson_flux_data_t* flux_data_for_build_rhs = d4est_poisson_flux_new(p4est, input_file, BC_DIRICHLET, &bc_data_for_rhs, problem_set_mortar_degree, NULL);
 
   problem_ctx_t ctx;
   ctx.flux_data_for_apply_lhs = flux_data_for_apply_lhs;
   ctx.flux_data_for_build_rhs = flux_data_for_build_rhs;
-                           
+
+
   d4est_elliptic_eqns_t prob_fcns;
   prob_fcns.build_residual = poisson_sinx_build_residual;
   prob_fcns.apply_lhs = poisson_sinx_apply_lhs;
   prob_fcns.user = &ctx;
-  
-  double* error = NULL;
-  double* u_analytic = NULL;
-  
+
+
   d4est_elliptic_data_t prob_vecs;
   prob_vecs.Au = P4EST_ALLOC(double, initial_nodes);
   prob_vecs.u = P4EST_ALLOC(double, initial_nodes);
@@ -157,7 +176,7 @@ problem_init
   d4est_poisson_flux_sipg_params_t* sipg_params = flux_data_for_apply_lhs->flux_data;
   
   
-  // Norm function contexts
+  // Setup norm function contexts
   
   d4est_norms_fcn_L2_ctx_t L2_norm_ctx;
   L2_norm_ctx.p4est = p4est;
@@ -165,93 +184,137 @@ problem_init
   L2_norm_ctx.d4est_geom = d4est_geom;
   L2_norm_ctx.d4est_quad = d4est_quad;
 
-
-  d4est_amr_t* d4est_amr =
-    d4est_amr_init
-    (
-     p4est,
-     input_file,
-     NULL
-    );
-
-  D4EST_ASSERT(d4est_amr->scheme->amr_scheme_type == AMR_UNIFORM_H ||
-               d4est_amr->scheme->amr_scheme_type == AMR_UNIFORM_P);
-
-  d4est_mesh_init_field
-    (
-     p4est,
-     prob_vecs.u,
-     poisson_sinx_initial_guess,
-     d4est_ops,
-     d4est_geom,
-     INIT_FIELD_ON_LOBATTO,
-     NULL
-    );
-    
-  d4est_poisson_build_rhs_with_strong_bc
-    (
-     p4est,
-     *ghost,
-     *ghost_data,
-     d4est_ops,
-     d4est_geom,
-     d4est_quad,
-     d4est_factors,
-     &prob_vecs,
-     flux_data_for_build_rhs,
-     prob_vecs.rhs,
-     poisson_sinx_rhs_fcn,
-     (init_params.eval_method == EVAL_BNDRY_FCN_ON_QUAD) ? INIT_FIELD_ON_QUAD : INIT_FIELD_ON_LOBATTO,
-     &ctx
-    );
-
   if (p4est->mpirank == 0)
     d4est_norms_write_headers(
       (const char * []){"u", NULL},
       (const char * []){"L_2", "L_infty", NULL}
     );
 
-  for (int level = 0; level < d4est_amr->num_of_amr_steps + 1; level++){
 
-    krylov_petsc_params_t krylov_petsc_params;
-    krylov_petsc_input(p4est, input_file, "krylov_petsc", "[KRYLOV_PETSC]", &krylov_petsc_params);
+  // Setup AMR
+  d4est_amr_t* d4est_amr = d4est_amr_init(
+    p4est,
+    input_file,
+    NULL
+  );
+
+  D4EST_ASSERT(
+    d4est_amr->scheme->amr_scheme_type == AMR_UNIFORM_H ||
+    d4est_amr->scheme->amr_scheme_type == AMR_UNIFORM_P
+  );
+
+  d4est_mesh_init_field(
+    p4est,
+    prob_vecs.u,
+    poisson_sinx_initial_guess,
+    d4est_ops,
+    d4est_geom,
+    INIT_FIELD_ON_LOBATTO,
+    NULL
+  );
     
-    krylov_petsc_solve
-      (
-       p4est,
-       &prob_vecs,
-       &prob_fcns,
-       ghost,
-       ghost_data,
-       d4est_ops,
-       d4est_geom,
-       d4est_quad,
-       d4est_factors,
-       &krylov_petsc_params,
-       NULL
+  d4est_poisson_build_rhs_with_strong_bc(
+    p4est,
+    *ghost,
+    *ghost_data,
+    d4est_ops,
+    d4est_geom,
+    d4est_quad,
+    d4est_factors,
+    &prob_vecs,
+    flux_data_for_build_rhs,
+    prob_vecs.rhs,
+    poisson_sinx_rhs_fcn,
+    (init_params.eval_method == EVAL_BNDRY_FCN_ON_QUAD) ? INIT_FIELD_ON_QUAD : INIT_FIELD_ON_LOBATTO,
+    &ctx
+  );
+
+
+  for (int level = 0; level < d4est_amr->num_of_amr_steps + 1; level++) {
+
+    // Setup multigrid
+    krylov_pc_t* pc = NULL;
+    if (init_params.use_multigrid == 1) {
+      int multigrid_min_level, multigrid_max_level;
+      multigrid_get_level_range(p4est, &multigrid_min_level, &multigrid_max_level);
+      zlog_debug(c_default, "Multigrid [min_level, max_level] = [%d,%d]", multigrid_min_level, multigrid_max_level);
+      
+      /* need to do a reduce on min,max_level before supporting multiple proc */
+      /* mpi_assert(proc_size == 1); */
+      int num_of_levels = multigrid_max_level + 1;
+      
+      multigrid_logger_t* logger = multigrid_logger_residual_init();
+      
+      multigrid_element_data_updater_t* updater = multigrid_element_data_updater_init(
+        num_of_levels,
+        ghost,
+        ghost_data,
+        d4est_factors,
+        problem_set_degrees_after_amr,
+        &init_params
       );
+      
+      multigrid_data_t* mg_data = multigrid_data_init(
+        p4est,
+        d4est_ops,
+        d4est_geom,
+        d4est_quad,
+        num_of_levels,
+        logger,
+        NULL,
+        updater,
+        input_file
+      );
+      
+      /* multigrid_solve */
+      /*   ( */
+      /*    p4est, */
+      /*    &prob_vecs, */
+      /*    &prob_fcns, */
+      /*    mg_data */
+      /*   ); */
+      
+      pc = krylov_pc_multigrid_create(mg_data, NULL);
+    }
+
+
+    // Krylov PETSc solve
+    
+    krylov_petsc_params_t krylov_petsc_params;
+    krylov_petsc_input(p4est, input_file, "krylov_petsc", &krylov_petsc_params);
+    
+    krylov_petsc_solve(
+      p4est,
+      &prob_vecs,
+      &prob_fcns,
+      ghost,
+      ghost_data,
+      d4est_ops,
+      d4est_geom,
+      d4est_quad,
+      d4est_factors,
+      &krylov_petsc_params,
+      pc
+    );
 
 
     // Compute and save mesh data to a VTK file
     
     // Compute analytical field values
     double* u_analytic = P4EST_ALLOC(double, prob_vecs.local_nodes);
-    d4est_mesh_init_field
-      (
-       p4est,
-       u_analytic,
-       poisson_sinx_analytic_solution,
-       d4est_ops, // unnecessary?
-       d4est_geom, // unnecessary?
-       INIT_FIELD_ON_LOBATTO,
-       NULL
-      );
+    d4est_mesh_init_field(
+      p4est,
+      u_analytic,
+      poisson_sinx_analytic_solution,
+      d4est_ops, // unnecessary?
+      d4est_geom, // unnecessary?
+      INIT_FIELD_ON_LOBATTO,
+      NULL
+    );
 
     // Compute errors between numerical and analytical field values
     double* error = P4EST_ALLOC(double, prob_vecs.local_nodes);
-    for (int i = 0; i < prob_vecs.local_nodes; i++){
-      error[i] = fabs(prob_vecs.u[i] - u_analytic[i]);
-    }
+    d4est_linalg_vec_fabsdiff(prob_vecs.u, u_analytic, error, prob_vecs.local_nodes);
 
     // Save to VTK file
     d4est_vtk_save(
@@ -265,21 +328,21 @@ problem_init
       (double* []){NULL},
       level
     );
-
-    P4EST_FREE(error);
     
     // Compute and save norms
     d4est_norms_save(
       p4est,
       (const char * []){ "u", NULL },
       (double * []){ prob_vecs.u },
-      (double * []){ u_analytic },
-      (d4est_xyz_fcn_t[]){ poisson_sinx_analytic_solution },
-      (void * []) { &ctx },
+      (double * []){ u_analytic }, // Using precomputed analytic field values
+      (d4est_xyz_fcn_t[]){ NULL },
+      (void * []) { NULL },
       (const char * []){"L_2", "L_infty", NULL},
       (d4est_norm_fcn_t[]){ &d4est_norms_fcn_L2, &d4est_norms_fcn_Linfty },
       (void * []){ &L2_norm_ctx, NULL }
     );
+    
+    P4EST_FREE(error);
     P4EST_FREE(u_analytic);
 
 
@@ -290,59 +353,55 @@ problem_init
       if (p4est->mpirank == 0)
         zlog_info(c_default, "Performing AMR refinement level %d of %d...", level + 1, d4est_amr->num_of_amr_steps);
 
-      d4est_amr_step
-        (
-         p4est,
-         ghost,
-         ghost_data,
-         d4est_ops,
-         d4est_amr,
-         &prob_vecs.u,
-         NULL
-        );
+      d4est_amr_step(
+        p4est,
+        ghost,
+        ghost_data,
+        d4est_ops,
+        d4est_amr,
+        &prob_vecs.u,
+        NULL
+      );
       
       if (p4est->mpirank == 0)
         zlog_info(c_default, "AMR refinement level %d of %d complete.", level + 1, d4est_amr->num_of_amr_steps);
     }
 
 
-    prob_vecs.local_nodes = d4est_mesh_update
-                  (
-                   p4est,
-                   *ghost,
-                   *ghost_data,
-                   d4est_ops,
-                   d4est_geom,
-                   d4est_quad,
-                   d4est_factors,
-                   INITIALIZE_QUADRATURE_DATA,
-                   INITIALIZE_GEOMETRY_DATA,
-                   INITIALIZE_GEOMETRY_ALIASES,
-                   d4est_mesh_set_quadratures_after_amr,
-                   initial_extents
-                  );
+    prob_vecs.local_nodes = d4est_mesh_update(
+      p4est,
+      *ghost,
+      *ghost_data,
+      d4est_ops,
+      d4est_geom,
+      d4est_quad,
+      d4est_factors,
+      INITIALIZE_QUADRATURE_DATA,
+      INITIALIZE_GEOMETRY_DATA,
+      INITIALIZE_GEOMETRY_ALIASES,
+      d4est_mesh_set_quadratures_after_amr,
+      initial_extents
+    );
 
-    
     prob_vecs.Au = P4EST_REALLOC(prob_vecs.Au, double, prob_vecs.local_nodes);
     prob_vecs.rhs = P4EST_REALLOC(prob_vecs.rhs, double, prob_vecs.local_nodes);
     
     
-    d4est_poisson_build_rhs_with_strong_bc
-      (
-       p4est,
-       *ghost,
-       *ghost_data,
-       d4est_ops,
-       d4est_geom,
-       d4est_quad,
-       d4est_factors,
-       &prob_vecs,
-       flux_data_for_build_rhs,
-       prob_vecs.rhs,
-       poisson_sinx_rhs_fcn,
-       (init_params.eval_method == EVAL_BNDRY_FCN_ON_QUAD) ? INIT_FIELD_ON_QUAD : INIT_FIELD_ON_LOBATTO,
-       &ctx
-      );
+    d4est_poisson_build_rhs_with_strong_bc(
+      p4est,
+      *ghost,
+      *ghost_data,
+      d4est_ops,
+      d4est_geom,
+      d4est_quad,
+      d4est_factors,
+      &prob_vecs,
+      flux_data_for_build_rhs,
+      prob_vecs.rhs,
+      poisson_sinx_rhs_fcn,
+      (init_params.eval_method == EVAL_BNDRY_FCN_ON_QUAD) ? INIT_FIELD_ON_QUAD : INIT_FIELD_ON_LOBATTO,
+      &ctx
+    );
   }
 
   if (p4est->mpirank == 0)
@@ -351,8 +410,6 @@ problem_init
   d4est_amr_destroy(d4est_amr);
   d4est_poisson_flux_destroy(flux_data_for_apply_lhs);
   d4est_poisson_flux_destroy(flux_data_for_build_rhs);
-  P4EST_FREE(error);
-  P4EST_FREE(u_analytic);
   P4EST_FREE(prob_vecs.u);
   P4EST_FREE(prob_vecs.Au);
   P4EST_FREE(prob_vecs.rhs);

--- a/Problems/Stamm/stamm_multigrid_pc.c
+++ b/Problems/Stamm/stamm_multigrid_pc.c
@@ -407,7 +407,7 @@ problem_init
     krylov_pc_t* pc = krylov_pc_multigrid_create(mg_data, NULL);
     
     krylov_petsc_params_t krylov_petsc_params;
-    krylov_petsc_input(p4est, input_file, "krylov_petsc", "[KRYLOV_PETSC]", &krylov_petsc_params);
+    krylov_petsc_input(p4est, input_file, "krylov_petsc", &krylov_petsc_params);
 
     krylov_petsc_solve
       (

--- a/Problems/TwoPunctures/multi_puncture.c
+++ b/Problems/TwoPunctures/multi_puncture.c
@@ -634,7 +634,7 @@ problem_init
       newton_petsc_input(p4est, input_file, "[NEWTON_PETSC]", &newton_params);
 
       krylov_petsc_params_t krylov_params;
-      krylov_petsc_input(p4est, input_file, "krylov_petsc", "[KRYLOV_PETSC]", &krylov_params);
+      krylov_petsc_input(p4est, input_file, "krylov_petsc", &krylov_params);
       
       newton_petsc_solve
         (

--- a/Problems/TwoPunctures/two_punctures_dirichlet_sphere_hp_mgpc_newton_petsc_cactus.c
+++ b/Problems/TwoPunctures/two_punctures_dirichlet_sphere_hp_mgpc_newton_petsc_cactus.c
@@ -650,7 +650,7 @@ problem_init
       newton_petsc_input(p4est, input_file, "[NEWTON_PETSC]", &newton_params);
 
       krylov_petsc_params_t krylov_params;
-      krylov_petsc_input(p4est, input_file, "krylov_petsc", "[KRYLOV_PETSC]", &krylov_params);
+      krylov_petsc_input(p4est, input_file, "krylov_petsc", &krylov_params);
       
       newton_petsc_solve
         (

--- a/Problems/TwoPunctures/two_punctures_robin_sphere_hp_mgpc_newton_petsc_cactus.c
+++ b/Problems/TwoPunctures/two_punctures_robin_sphere_hp_mgpc_newton_petsc_cactus.c
@@ -655,7 +655,7 @@ problem_init
       newton_petsc_input(p4est, input_file, "[NEWTON_PETSC]", &newton_params);
 
       krylov_petsc_params_t krylov_params;
-      krylov_petsc_input(p4est, input_file, "krylov_petsc", "[KRYLOV_PETSC]", &krylov_params);
+      krylov_petsc_input(p4est, input_file, "krylov_petsc", &krylov_params);
       
       newton_petsc_solve
         (

--- a/Solver/krylov_petsc.c
+++ b/Solver/krylov_petsc.c
@@ -35,12 +35,12 @@ int krylov_petsc_input_handler
     D4EST_ASSERT(pconfig->ksp_view == -1);
     pconfig->ksp_view = atoi(value);
     D4EST_ASSERT(atoi(value) == 0 || atoi(value) == 1);
-  }  
+  }
   else if (d4est_util_match_couple(section,pconfig->input_section,name,"ksp_monitor")) {
     D4EST_ASSERT(pconfig->ksp_monitor == -1);
     pconfig->ksp_monitor = atoi(value);
     D4EST_ASSERT(atoi(value) == 0 || atoi(value) == 1);
-  } 
+  }
   else if (d4est_util_match_couple(section,pconfig->input_section,name,"ksp_converged_reason")) {
     D4EST_ASSERT(pconfig->ksp_converged_reason == -1);
     pconfig->ksp_converged_reason = atoi(value);
@@ -49,12 +49,12 @@ int krylov_petsc_input_handler
   else if (d4est_util_match_couple(section,pconfig->input_section,name,"ksp_monitor_singular_value")) {
     pconfig->ksp_monitor_singular_value = atoi(value);
     D4EST_ASSERT(atoi(value) == 0 || atoi(value) == 1);
-  }      
+  }
   else if (d4est_util_match_couple(section,pconfig->input_section,name,"ksp_initial_guess_nonzero")) {
     D4EST_ASSERT(pconfig->ksp_initial_guess_nonzero == -1);
     pconfig->ksp_initial_guess_nonzero = atoi(value);
     D4EST_ASSERT(atoi(value) == 0 || atoi(value) == 1);
-  }  
+  }
   else if (d4est_util_match_couple(section,pconfig->input_section,name,"ksp_type")) {
     D4EST_ASSERT(pconfig->ksp_type[0] == '*');
     snprintf (pconfig->ksp_type, sizeof(pconfig->ksp_type), "%s", value);
@@ -76,7 +76,7 @@ int krylov_petsc_input_handler
     D4EST_ASSERT(pconfig->ksp_do_not_use_preconditioner == 0);
     pconfig->ksp_do_not_use_preconditioner = atoi(value);
     D4EST_ASSERT(atoi(value) == 0 || atoi(value) == 1);
-  }  
+  }
   
   else {
     return 0;  /* unknown section/name, error */
@@ -145,7 +145,6 @@ krylov_petsc_input
  p4est_t* p4est,
  const char* input_file,
  const char* input_section,
- const char* printf_prefix,
  krylov_petsc_params_t* input
 )
 {
@@ -185,19 +184,20 @@ krylov_petsc_input
   }
     
   if(p4est->mpirank == 0){
-    printf("%s: ksp_type = %s\n",printf_prefix, input->ksp_type);
-    printf("%s: ksp_view = %d\n",printf_prefix, input->ksp_view);
-    printf("%s: ksp_monitor = %d\n",printf_prefix, input->ksp_monitor);
-    printf("%s: ksp_atol = %s\n",printf_prefix, input->ksp_atol);
-    printf("%s: ksp_rtol = %s\n",printf_prefix, input->ksp_rtol);
-    printf("%s: ksp_maxit = %s\n",printf_prefix, input->ksp_max_it);
-    printf("%s: ksp_converged_reason = %d\n",printf_prefix, input->ksp_converged_reason);
-    printf("%s: ksp_initial_guess_nonzero = %d\n",printf_prefix, input->ksp_initial_guess_nonzero);
-    printf("%s: ksp_do_not_use_preconditioner = %d\n",printf_prefix, input->ksp_do_not_use_preconditioner);
+    zlog_category_t *c_default = zlog_get_category("krylov_petsc");
+    zlog_debug(c_default, "ksp_type = %s", input->ksp_type);
+    zlog_debug(c_default, "ksp_view = %d", input->ksp_view);
+    zlog_debug(c_default, "ksp_monitor = %d", input->ksp_monitor);
+    zlog_debug(c_default, "ksp_atol = %s", input->ksp_atol);
+    zlog_debug(c_default, "ksp_rtol = %s", input->ksp_rtol);
+    zlog_debug(c_default, "ksp_maxit = %s", input->ksp_max_it);
+    zlog_debug(c_default, "ksp_converged_reason = %d", input->ksp_converged_reason);
+    zlog_debug(c_default, "ksp_initial_guess_nonzero = %d", input->ksp_initial_guess_nonzero);
+    zlog_debug(c_default, "ksp_do_not_use_preconditioner = %d", input->ksp_do_not_use_preconditioner);
     if(d4est_util_match(input->ksp_type,"chebyshev")){
-      printf("%s: ksp_chebyshev_esteig_steps = %s\n",printf_prefix, input->ksp_chebyshev_esteig_steps);
-      printf("%s: ksp_chebyshev_esteig = %s\n",printf_prefix, input->ksp_chebyshev_esteig);
-      printf("%s: ksp_chebyshev_esteig_random = %d\n",printf_prefix, input->ksp_chebyshev_esteig_random);
+      zlog_debug(c_default, "ksp_chebyshev_esteig_steps = %s", input->ksp_chebyshev_esteig_steps);
+      zlog_debug(c_default, "ksp_chebyshev_esteig = %s", input->ksp_chebyshev_esteig);
+      zlog_debug(c_default, "ksp_chebyshev_esteig_random = %d", input->ksp_chebyshev_esteig_random);
     }
   }
 
@@ -215,7 +215,7 @@ PetscErrorCode krylov_petsc_apply_aij( Mat A, Vec x, Vec y )
   double* py;
 
   /* PetscFunctionBegin; */
-  ierr = MatShellGetContext( A, &ctx ); CHKERRQ(ierr);  
+  ierr = MatShellGetContext( A, &ctx ); CHKERRQ(ierr);
   petsc_ctx = (petsc_ctx_t *)ctx;
   ierr = VecGetArrayRead( x, &px ); CHKERRQ(ierr);
   ierr = VecGetArray( y, &py ); CHKERRQ(ierr);
@@ -280,7 +280,7 @@ krylov_petsc_solve
  d4est_elliptic_data_t* vecs,
  d4est_elliptic_eqns_t* fcns,
  p4est_ghost_t** ghost,
- d4est_element_data_t** ghost_data, 
+ d4est_element_data_t** ghost_data,
  d4est_operators_t* d4est_ops,
  d4est_geometry_t* d4est_geom,
  d4est_quadrature_t* d4est_quad,
@@ -289,6 +289,10 @@ krylov_petsc_solve
  krylov_pc_t* krylov_pc
 )
 {
+  zlog_category_t *c_default = zlog_get_category("krylov_petsc");
+  if (p4est->mpirank == 0)
+    zlog_info(c_default, "Performing Krylov PETSc solve...");
+
   krylov_petsc_set_options_database_from_params(krylov_petsc_params);
 
   krylov_info_t info;
@@ -317,7 +321,7 @@ krylov_petsc_solve
   /* DEBUG_PRINT_ARR_DBL_SUM(u, local_nodes); */
   /* DEBUG_PRINT_ARR_DBL_SUM(rhs, local_nodes); */
   
-  KSPCreate(PETSC_COMM_WORLD,&ksp);  
+  KSPCreate(PETSC_COMM_WORLD,&ksp);
   VecCreate(PETSC_COMM_WORLD,&x);//CHKERRQ(ierr);
   VecSetSizes(x, local_nodes, PETSC_DECIDE);//CHKERRQ(ierr);
   VecSetFromOptions(x);//CHKERRQ(ierr);
@@ -352,7 +356,7 @@ krylov_petsc_solve
      PETSC_DETERMINE,
      (void*)&petsc_ctx,
      &A
-    ); 
+    );
   MatShellSetOperation(A,MATOP_MULT,(void(*)())krylov_petsc_apply_aij);
 
   /* Set Amat and Pmat, where Pmat is the matrix the Preconditioner needs */
@@ -371,6 +375,9 @@ krylov_petsc_solve
   VecDestroy(&x);
   VecDestroy(&b);
   KSPDestroy(&ksp);
+  
+  if (p4est->mpirank == 0)
+    zlog_info(c_default, "Krylov PETSc solve complete.");
 
   return info;
 }

--- a/Solver/krylov_petsc.h
+++ b/Solver/krylov_petsc.h
@@ -1,5 +1,5 @@
 #ifndef KSP_PETSC_SOLVE_H
-#define KSP_PETSC_SOLVE_H 
+#define KSP_PETSC_SOLVE_H
 
 #include <petscsnes.h>
 #include <pXest.h>
@@ -35,7 +35,7 @@ typedef struct {
 
 /* This file was automatically generated.  Do not edit! */
 krylov_info_t krylov_petsc_solve(p4est_t *p4est,d4est_elliptic_data_t *vecs,d4est_elliptic_eqns_t *fcns,p4est_ghost_t **ghost,d4est_element_data_t **ghost_data,d4est_operators_t *d4est_ops,d4est_geometry_t *d4est_geom,d4est_quadrature_t *d4est_quad,d4est_mesh_data_t *d4est_factors,krylov_petsc_params_t *krylov_petsc_params,krylov_pc_t *krylov_pc);
-void krylov_petsc_input(p4est_t *p4est,const char *input_file,const char *input_section,const char *printf_prefix,krylov_petsc_params_t *input);
+void krylov_petsc_input(p4est_t *p4est,const char *input_file,const char *input_section,krylov_petsc_params_t *input);
 void krylov_petsc_set_options_database_from_params(krylov_petsc_params_t *input);
 
 #endif

--- a/Solver/multigrid.c
+++ b/Solver/multigrid.c
@@ -41,7 +41,7 @@ multigrid_get_level_range
         min = (level < min) ? level : min;
         max = (level > max) ? level : max;
       }
-    }  
+    }
 
 
   int local_reduce [2];
@@ -95,7 +95,7 @@ multigrid_update_components
     if (mg_data->bottom_solver->update != NULL){
       mg_data->bottom_solver->update(p4est, level, data);
     }
-  }   
+  }
 
   if (mg_data->smoother != NULL){
     if (mg_data->smoother->update != NULL){
@@ -410,7 +410,7 @@ multigrid_vcycle
   /**********************************************************/
   /******************* BEGIN GOING DOWN V *******************/
   /**********************************************************/
-  /**********************************************************/  
+  /**********************************************************/
   /* DEBUG_PRINT_ARR_DBL(vecs->u, vecs->local_nodes); */
 
   #ifdef DEBUG_INFO
@@ -420,7 +420,7 @@ multigrid_vcycle
   printf("elements_on_surrogate_level = %d\n", elements_on_level_of_surrogate_multigrid[toplevel]);
   printf("nodes_on_level = %d\n", nodes_on_level_of_multigrid[toplevel]);
   printf("nodes_on_surrogate_level = %d\n", nodes_on_level_of_surrogate_multigrid[toplevel]);
-#endif    
+#endif
   mg_data->mg_state = PRE_V; multigrid_update_components(p4est, toplevel, NULL);
 
   
@@ -434,14 +434,14 @@ multigrid_vcycle
     /**********************************************************/
     /******************* PRE SMOOTH ***************************/
     /**********************************************************/
-    /**********************************************************/  
+    /**********************************************************/
     
     /* set initial guess for error */
     d4est_linalg_fill_vec(&err_at0[stride_to_fine_data], 0., nodes_on_level_of_multigrid[level]);//mg_data->fine_nodes);
 
     if (level == toplevel){
       vecs_for_smooth.Au = vecs->Au;
-      vecs_for_smooth.u = vecs->u; 
+      vecs_for_smooth.u = vecs->u;
       vecs_for_smooth.rhs = vecs->rhs;
       vecs_for_smooth.local_nodes = vecs->local_nodes;
     }
@@ -456,7 +456,7 @@ multigrid_vcycle
     /**********************************************************/
     /******************* BEGIN SMOOTH *************************/
     /**********************************************************/
-    /**********************************************************/  
+    /**********************************************************/
 
 #ifdef DEBUG_INFO
     printf("Level = %d\n", level);
@@ -484,21 +484,21 @@ multigrid_vcycle
     printf("elements_on_surrogate_level = %d\n", elements_on_level_of_surrogate_multigrid[level]);
     printf("nodes_on_level = %d\n", nodes_on_level_of_multigrid[level]);
     printf("nodes_on_surrogate_level = %d\n", nodes_on_level_of_surrogate_multigrid[level]);
-#endif    
+#endif
     mg_data->mg_state = DOWNV_POST_SMOOTH; multigrid_update_components(p4est, level, &vecs_for_smooth);
     
     /**********************************************************/
     /**********************************************************/
     /********************* END SMOOTH *************************/
     /**********************************************************/
-    /**********************************************************/  
+    /**********************************************************/
 
 
     /**********************************************************/
     /**********************************************************/
     /******************* BEGIN COARSEN ************************/
     /**********************************************************/
-    /**********************************************************/  
+    /**********************************************************/
 #ifdef DEBUG_INFO
     printf("Level = %d\n", level);
     printf("State = %s\n", "DOWNV_PRE_COARSEN");
@@ -533,7 +533,7 @@ multigrid_vcycle
     /**********************************************************/
     /******************* END COARSEN **************************/
     /**********************************************************/
-    /**********************************************************/  
+    /**********************************************************/
     
     /* p4est has changed, so update the element data, this does not change the stride */
     /* element_data_init(p4est, -1); */
@@ -552,8 +552,8 @@ multigrid_vcycle
     /**********************************************************/
     /******************* BEGIN BALANCE ************************/
     /**********************************************************/
-    /**********************************************************/  
-    mg_data->mg_state = DOWNV_PRE_BALANCE; multigrid_update_components(p4est, level, NULL);   
+    /**********************************************************/
+    mg_data->mg_state = DOWNV_PRE_BALANCE; multigrid_update_components(p4est, level, NULL);
     
     /* does not change the stride */
     p4est_balance_ext (p4est, P4EST_CONNECT_FACE, NULL, multigrid_store_balance_changes);
@@ -563,7 +563,7 @@ multigrid_vcycle
     /**********************************************************/
     /******************* END BALANCE **************************/
     /**********************************************************/
-    /**********************************************************/  
+    /**********************************************************/
     
     /* element_data_init(p4est, -1); */
 
@@ -626,10 +626,10 @@ multigrid_vcycle
     printf("elements_on_level = %d\n", elements_on_level_of_multigrid[level]);
     printf("elements_on_surrogate_level = %d\n", elements_on_level_of_surrogate_multigrid[level]);
     printf("nodes_on_level = %d\n", nodes_on_level_of_multigrid[level]);
-    printf("nodes_on_surrogate_level = %d\n", nodes_on_level_of_surrogate_multigrid[level]);    
+    printf("nodes_on_surrogate_level = %d\n", nodes_on_level_of_surrogate_multigrid[level]);
 #endif
     
-    mg_data->mg_state = DOWNV_POST_RESTRICTION; multigrid_update_components(p4est, level, NULL);   
+    mg_data->mg_state = DOWNV_POST_RESTRICTION; multigrid_update_components(p4est, level, NULL);
 
     d4est_linalg_copy_1st_to_2nd
       (
@@ -665,7 +665,7 @@ multigrid_vcycle
   vecs_for_bottom_solve.local_nodes = nodes_on_level_of_multigrid[bottomlevel];
 
 
-  mg_data->mg_state = COARSE_PRE_SOLVE; multigrid_update_components(p4est, level, &vecs_for_bottom_solve);   
+  mg_data->mg_state = COARSE_PRE_SOLVE; multigrid_update_components(p4est, level, &vecs_for_bottom_solve);
   
   mg_data->bottom_solver->solve
     (
@@ -676,7 +676,7 @@ multigrid_vcycle
      &rres_at0[stride_to_fine_data]//[mg_data->fine_nodes]),
     );
 
-  mg_data->mg_state = COARSE_POST_SOLVE; multigrid_update_components(p4est, level, &vecs_for_bottom_solve);   
+  mg_data->mg_state = COARSE_POST_SOLVE; multigrid_update_components(p4est, level, &vecs_for_bottom_solve);
 
   /* d4est_util_print_matrix(&rres_at0[stride_to_fine_data],mg_data->coarse_nodes,1,"rres coarse solve= ", 0); */
   
@@ -722,7 +722,7 @@ multigrid_vcycle
     /**********************************************************/
 
     
-    mg_data->mg_state = UPV_PRE_REFINE; multigrid_update_components(p4est, level, NULL);   
+    mg_data->mg_state = UPV_PRE_REFINE; multigrid_update_components(p4est, level, NULL);
     
     /* increments the stride */
     p4est_refine_ext(p4est,
@@ -734,7 +734,7 @@ multigrid_vcycle
                     );
 
 
-    mg_data->mg_state = UPV_POST_REFINE; multigrid_update_components(p4est, level, NULL);   
+    mg_data->mg_state = UPV_POST_REFINE; multigrid_update_components(p4est, level, NULL);
 
 
     /**********************************************************/
@@ -781,7 +781,7 @@ multigrid_vcycle
     /**********************************************************/
     
 
-    mg_data->mg_state = UPV_PRE_SMOOTH; multigrid_update_components(p4est, level, &vecs_for_smooth);   
+    mg_data->mg_state = UPV_PRE_SMOOTH; multigrid_update_components(p4est, level, &vecs_for_smooth);
     
     mg_data->smoother->smooth
       (
@@ -792,7 +792,7 @@ multigrid_vcycle
        fine_level
       );
 
-    mg_data->mg_state = UPV_POST_SMOOTH; multigrid_update_components(p4est, level, &vecs_for_smooth);   
+    mg_data->mg_state = UPV_POST_SMOOTH; multigrid_update_components(p4est, level, &vecs_for_smooth);
 
 
     /**********************************************************/
@@ -854,7 +854,7 @@ multigrid_compute_residual
   /* d4est_geometry_t* d4est_geom = mg_data->d4est_geom; */
   
   if (mg_data->mg_state == START){
-    double* Au; 
+    double* Au;
     double* rhs;
     int local_nodes = vecs->local_nodes;
     Au = vecs->Au;
@@ -876,7 +876,7 @@ multigrid_compute_residual
 
     
     d4est_linalg_vec_axpyeqz(-1., Au, rhs, r, local_nodes);
-    double r2_0_local = d4est_linalg_vec_dot(r,r,local_nodes);  
+    double r2_0_local = d4est_linalg_vec_dot(r,r,local_nodes);
     P4EST_FREE(r);
   
     double r2_0_global = -1;
@@ -888,7 +888,7 @@ multigrid_compute_residual
        sc_MPI_DOUBLE,
        sc_MPI_SUM,
        sc_MPI_COMM_WORLD
-      );  
+      );
   
     return r2_0_global;
   }
@@ -942,7 +942,7 @@ multigrid_solve
   multigrid_update_components(p4est, -1, NULL);
   /**
    * START VCYCLING
-   * 
+   *
    */
   while
     (

--- a/Solver/multigrid_bottom_solver_krylov_petsc.c
+++ b/Solver/multigrid_bottom_solver_krylov_petsc.c
@@ -2,7 +2,7 @@
 #include <krylov_petsc.h>
 
 
-static void 
+static void
 multigrid_bottom_solver_krylov_petsc
 (
  p4est_t* p4est,
@@ -48,6 +48,10 @@ multigrid_bottom_solver_krylov_petsc_init
  const char* input_file
 )
 {
+  zlog_category_t *c_default = zlog_get_category("solver_multigrid_bottom");
+  if (p4est->mpirank == 0)
+    zlog_info(c_default, "Initializing multigrid bottom solver...");
+
   multigrid_bottom_solver_t* bottom_solver = P4EST_ALLOC(multigrid_bottom_solver_t, 1);
   krylov_petsc_params_t* params = P4EST_ALLOC(krylov_petsc_params_t, 1);
 
@@ -56,13 +60,15 @@ multigrid_bottom_solver_krylov_petsc_init
      p4est,
      input_file,
      "mg_bottom_solver_krylov_petsc",
-     "[MG_BOTTOM_SOLVER_KRYLOV_PETSC]",
      params
     );
   
   bottom_solver->user = params;
   bottom_solver->solve = multigrid_bottom_solver_krylov_petsc;
   bottom_solver->update = NULL;
+
+  if (p4est->mpirank == 0)
+    zlog_info(c_default, "Initialization of multigrid bottom solver complete.");
 
   return bottom_solver;
 }

--- a/Solver/multigrid_smoother_krylov_petsc.c
+++ b/Solver/multigrid_smoother_krylov_petsc.c
@@ -2,7 +2,7 @@
 #include <krylov_petsc.h>
 #include <d4est_linalg.h>
 
-static void 
+static void
 multigrid_smoother_krylov_petsc
 (
  p4est_t* p4est,
@@ -64,6 +64,10 @@ multigrid_smoother_krylov_petsc_init
  const char* input_file
 )
 {
+  zlog_category_t *c_default = zlog_get_category("solver_multigrid_smoother");
+  if (p4est->mpirank == 0)
+    zlog_info(c_default, "Initializing multigrid smoother solver...");
+
   multigrid_smoother_t* smoother = P4EST_ALLOC(multigrid_smoother_t, 1);
   krylov_petsc_params_t* params = P4EST_ALLOC(krylov_petsc_params_t, 1);
 
@@ -72,13 +76,15 @@ multigrid_smoother_krylov_petsc_init
      p4est,
      input_file,
      "mg_smoother_krylov_petsc",
-     "[MG_SMOOTHER_KRYLOV_PETSC]",
      params
     );
   
   smoother->user = params;
   smoother->smooth = multigrid_smoother_krylov_petsc;
   smoother->update = NULL;
+
+  if (p4est->mpirank == 0)
+    zlog_info(c_default, "Initialization of multigrid smoother solver complete.");
 
   return smoother;
 }


### PR DESCRIPTION
Hi Trevor, is there a reason you keep the example problems in separate files, for instance `poisson_sinx_uniform.c` and `poisson_sinx_multigrid.c`? Perhaps it's more reliable to reproduce examples, and compare features, if the features (e.g. multigrid) are switched on and off by the `.input` parameters? To give you an example, in this commit I added the multigrid functionality to `poisson_sinx_uniform.c` and implemented it so that it is only used if the `[multigrid]` section is present in the `.input` file.